### PR TITLE
feat: Add more valid Firefox user agents

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,20 +5,6 @@
 # DOCKER_PASS
 #
 version: 2.1
-commands:
-  write-version:
-    steps:
-      - run:
-          name: Create a version.json
-          command: |
-            # create a version.json per
-            # https://github.com/mozilla-services/Dockerflow/blob/master/docs/version_object.md
-            printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
-            "$CIRCLE_SHA1" \
-            "$CIRCLE_TAG" \
-            "$CIRCLE_PROJECT_USERNAME" \
-            "$CIRCLE_PROJECT_REPONAME" \
-            "$CIRCLE_BUILD_URL" > version.json
 jobs:
   test:
     docker:
@@ -38,7 +24,6 @@ jobs:
                 echo "${DOCKER_PASS}" | docker login -u="${DOCKER_USER}" --password-stdin
               fi
       - checkout
-      - write-version
       - run:
           name: Install Docker test dependencies
           command: pip install flake8

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ $ pip install -r requirements.txt
 
 ## Usage:
 
-The following environment variables must be set:
-* `TIMEOUT`: The timeout (in seconds) for the request made to Contile
-* `TARGET_URL`: The URL of the endpoint to be load tested
-* `TEST_LOCATION_HEADER_NAME`: The of the HTTP header used to manually specify the location from which the request originated. This should match the value of CONTILE_LOCATION_TEST_HEADER on Contile
+The load tests make use of the following environment variables:
+* `TIMEOUT`: The timeout (in seconds) for the request made to Contile (defaults to 5)
+* `TARGET_URL`: The URL of the endpoint to be load tested (defaults to `http://localhost:8000/v1/tiles`)
+* `TEST_LOCATION_HEADER_NAME`: The of the HTTP header used to manually specify the location from which the request originated. This should match the value of CONTILE_LOCATION_TEST_HEADER on Contile (defaults to `X-Test-Location`)
 
 The load tests were written using
 [Molotov](https://molotov.readthedocs.io/en/stable/) and can be started using

--- a/loadtest.py
+++ b/loadtest.py
@@ -8,22 +8,40 @@ _CLDR_SUBDIVISION_FILENAME = 'unicode_cldr_subdivision_codes.xml'
 _TARGET_URL = os.environ.get('TARGET_URL', 'http://localhost:8000/v1/tiles')
 _TEST_LOCATION_HEADER_NAME = os.environ.get(
     'TEST_LOCATION_HEADER_NAME', 'X-Test-Location')
-_TEST_USER_AGENTS = [
+_TEST_FIREFOX_USER_AGENTS = [
+    'Mozilla/5.0 (Windows NT 10.0; rv:10.0) Gecko/20100101 Firefox/10.0',
+
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:10.0) Gecko/20100101 '
+    'Firefox/10.0',
+
+    'Mozilla/5.0 (X11; Linux x86_64; rv:10.0) Gecko/20100101 Firefox/10.0',
+    'Mozilla/5.0 (Android; Mobile; rv:40.0) Gecko/40.0 Firefox/40.0',
+    'Mozilla/5.0 (Android; Tablet; rv:40.0) Gecko/40.0 Firefox/40.0',
+    'Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0',
+    'Mozilla/5.0 (Android 4.4; Tablet; rv:41.0) Gecko/41.0 Firefox/41.0',
+
+    'Mozilla/5.0 (iPod touch; CPU iPhone OS 8_3 like Mac OS X) '
+    'AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 '
+    'Safari/600.1.4',
+
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) '
+    'AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 '
+    'Mobile/12F69 Safari/600.1.4',
+
+    'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) '
+    'AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 '
+    'Mobile/12F69 Safari/600.1.4'
+]
+_TEST_NON_FIREFOX_USER_AGENTS = [
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, '
     'like Gecko) Chrome/58.0.3029.110 Safari/537.36',
-
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:53.0) '
-    'Gecko/20100101 Firefox/53.0',
-
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, '
-    'like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393',
 
     'Mozilla/5.0 (iPad; CPU OS 8_4_1 like Mac OS X) AppleWebKit/600.1.4 '
     '(KHTML, like Gecko) Version/8.0 Mobile/12H321 Safari/600.1.4',
 
     'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) '
-    'AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 '
-    'Mobile/14E304 Safari/602.1',
+    'AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 '
+    'Safari/602.1',
 
     'Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G570Y Build/MMB29K) '
     'AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 '
@@ -32,13 +50,23 @@ _TEST_USER_AGENTS = [
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4) AppleWebKit/605.1.15 '
     '(KHTML, like Gecko) Version/14.1 Safari/605.1.15',
 
-    'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_4) AppleWebKit/537.36 '
-    '(KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36',
+    'Mozilla/5.0 (Linux; Android 8.0.0; SM-G960F Build/R16NW) '
+    'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile '
+    'Safari/537.36',
 
-    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) '
-    'Chrome/90.0.4430.212 Safari/537.36',
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) '
+    'AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/69.0.3497.105 '
+    'Mobile/15E148 Safari/605.1',
 
-    'Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko'
+    'Mozilla/5.0 (Linux; Android 7.0; Pixel C Build/NRD90M; wv) '
+    'AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.98 '
+    'Safari/537.36',
+
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, '
+    'like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246',
+
+    'Mozilla/5.0 (X11; CrOS x86_64 8172.45.0) AppleWebKit/537.36 (KHTML, like '
+    'Gecko) Chrome/51.0.2704.64 Safari/537.36'
 ]
 _TIMEOUT = float(os.environ.get('TIMEOUT', 5.0))
 
@@ -55,9 +83,9 @@ _TEST_LOCATIONS = parse_subdivision_codes_file()
 
 
 @scenario()
-async def request_from_consistent_location_with_consistent_user_agent(session):
+async def request_from_consistent_location_with_consistent_firefox_user_agent(session):  # noqa: E501
     headers = {
-        'User-Agent': _TEST_USER_AGENTS[0],
+        'User-Agent': _TEST_FIREFOX_USER_AGENTS[0],
         _TEST_LOCATION_HEADER_NAME: 'US, USCA'
     }
     timeout = ClientTimeout(total=_TIMEOUT)
@@ -69,9 +97,9 @@ async def request_from_consistent_location_with_consistent_user_agent(session):
 
 
 @scenario()
-async def request_from_random_location_with_consistent_user_agent(session):
+async def request_from_random_location_with_consistent_firefox_user_agent(session):  # noqa: E501
     headers = {
-        'User-Agent': _TEST_USER_AGENTS[0],
+        'User-Agent': _TEST_FIREFOX_USER_AGENTS[0],
         _TEST_LOCATION_HEADER_NAME: get_random_location()
     }
     timeout = ClientTimeout(total=_TIMEOUT)
@@ -79,14 +107,13 @@ async def request_from_random_location_with_consistent_user_agent(session):
     async with session.get(_TARGET_URL,
                            headers=headers,
                            timeout=timeout) as resp:
-
         assert resp.status == 200
 
 
 @scenario()
-async def request_from_consistent_location_with_random_user_agent(session):
+async def request_from_consistent_location_with_random_firefox_user_agent(session):  # noqa: E501
     headers = {
-        'User-Agent': get_random_user_agent(),
+        'User-Agent': random.choice(_TEST_FIREFOX_USER_AGENTS),
         _TEST_LOCATION_HEADER_NAME: 'US, USCA'
     }
     timeout = ClientTimeout(total=_TIMEOUT)
@@ -98,9 +125,9 @@ async def request_from_consistent_location_with_random_user_agent(session):
 
 
 @scenario()
-async def request_from_random_location_with_random_user_agent(session):
+async def request_from_random_location_with_random_firefox_user_agent(session):
     headers = {
-        'User-Agent': get_random_user_agent(),
+        'User-Agent': random.choice(_TEST_FIREFOX_USER_AGENTS),
         _TEST_LOCATION_HEADER_NAME: get_random_location()
     }
     timeout = ClientTimeout(total=_TIMEOUT)
@@ -109,6 +136,20 @@ async def request_from_random_location_with_random_user_agent(session):
                            headers=headers,
                            timeout=timeout) as resp:
         assert resp.status == 200
+
+
+@scenario()
+async def request_with_random_non_firefox_user_agent(session):
+    user_agent = random.choice(_TEST_NON_FIREFOX_USER_AGENTS)
+    headers = {'User-Agent': user_agent}
+    timeout = ClientTimeout(total=_TIMEOUT)
+
+    async with session.get(_TARGET_URL,
+                           headers=headers,
+                           timeout=timeout) as resp:
+        # Contile should send an empty response to a request from a non-Firefox
+        # user agent
+        assert resp.status == 204
 
 
 def get_random_location():
@@ -119,7 +160,3 @@ def get_random_location():
     subdivision = random.choice(subdivisions)
 
     return f'{code}, {subdivision.upper()}'
-
-
-def get_random_user_agent():
-    return random.choice(_TEST_USER_AGENTS)

--- a/loadtest.py
+++ b/loadtest.py
@@ -149,7 +149,7 @@ async def request_with_random_non_firefox_user_agent(session):
                            timeout=timeout) as resp:
         # Contile should send an empty response to a request from a non-Firefox
         # user agent
-        assert resp.status == 204
+        assert resp.status == 403
 
 
 def get_random_location():


### PR DESCRIPTION
## Description

* Separates user agents into two lists: one for Firefox user agents and one for non-Firefox user agents
* Adds additional user agents
* Adds a scenario that specifically tests whether Contile returns an empty response (status code 204) in response to a non-Firefox user agent

## Testing

I was able to test this by running each of the scenarios and ensuring that Contile responded/cached appropriately based on the location and user agent. The `request_with_random_non_firefox_user_agent` scenario cannot currently be tested, since Contile isn't currently handling non-Firefox UAs correctly (this will be resolved in [#124](https://github.com/mozilla-services/contile/issues/124)).

## Issue(s)

Closes #10
